### PR TITLE
fix: add types and make global functions local

### DIFF
--- a/lua/better-comment/init.lua
+++ b/lua/better-comment/init.lua
@@ -1,13 +1,27 @@
 -- TODO: don't having to resave to remove extmark
 -- TODO: see the others TODO
 
+---@class (exact) CommentHighlight
+---@field name string
+---@field fg string?
+---@field bg string?
+---@field bold boolean?
+---@field underline boolean?
+---@field virtual_text string?
+
+---These strings are passed to string.match!
+---@alias BetterComments.tags CommentHighlight[]
+
 
 local M = {}
 
 local api = vim.api
 local cmd = vim.api.nvim_create_autocmd
 local treesitter = vim.treesitter
+---@class BetterCommentsConfig
 local opts = {
+    default = true,
+    ---@type CommentHighlight[]
     tags = {
         {
             name = "TODO",
@@ -36,11 +50,33 @@ local opts = {
 }
 
 
-M.Setup = function(config)
-    if config and config.default==false then
+---@param bufnr integer
+---@param filetype string
+local function Get_root(bufnr, filetype)
+    local parser = vim.treesitter.get_parser(bufnr, filetype, {})
+    local tree = parser:parse()[1]
+    return tree:root()
+end
+
+---@param list CommentHighlight[]
+local function Create_hl(list)
+    for id, hl in ipairs(list) do
+        vim.api.nvim_set_hl(0, tostring(id), {
+            fg = hl.fg,
+            bg = hl.bg,
+            bold = hl.bold,
+            underline = hl.underline,
+        })
+    end
+end
+
+---@param config? BetterCommentsConfig
+function M.Setup(config)
+    config = config or {}
+    if config.default==false then
         opts.tags = {}
     end
-    if config and config.tags then
+    if config.tags then
         opts.tags = vim.tbl_deep_extend("force", opts.tags, config.tags or {})
     end
 
@@ -116,23 +152,6 @@ M.Setup = function(config)
             end
         end
     })
-end
-
-Get_root = function(bufnr, filetype)
-    local parser = vim.treesitter.get_parser(bufnr, filetype, {})
-    local tree = parser:parse()[1]
-    return tree:root()
-end
-
-function Create_hl(list)
-    for id, hl in ipairs(list) do
-        vim.api.nvim_set_hl(0, tostring(id), {
-            fg = hl.fg,
-            bg = hl.bg,
-            bold = hl.bold,
-            underline = hl.underline,
-        })
-    end
 end
 
 return M

--- a/lua/better-comment/init.lua
+++ b/lua/better-comment/init.lua
@@ -9,10 +9,6 @@
 ---@field underline boolean?
 ---@field virtual_text string?
 
----These strings are passed to string.match!
----@alias BetterComments.tags CommentHighlight[]
-
-
 local M = {}
 
 local api = vim.api


### PR DESCRIPTION
this commit adds a CommentHighlight type which describes each tag, and a BetterCommentsConfig type which describes the configuration
It adds param markers to the functions defined
Finally, it make the Get_root and Create_hl functions local instead of global and moves them to ensure they stay in needed scope
